### PR TITLE
クライアント初期化時にapi-client-goのオプションをサポート

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,8 +91,7 @@ func NewMessageClientWithApiUrl(apiUrl, apiKey string, params ...client.ClientPa
 					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 					return nil
 				},
-			}}),
-	},
+			}})},
 		params...)...)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -47,12 +47,14 @@ func (ss DummySecuritySource) ApiKeyAuth(ctx context.Context, operationName queu
 	return queue.ApiKeyAuth{Username: ss.Token}, nil
 }
 
-func NewQueueClient() (*queue.Client, error) {
-	return NewQueueClientWithApiUrl(DefaultQueueAPIRootURL)
+func NewQueueClient(params ...client.ClientParam) (*queue.Client, error) {
+	return NewQueueClientWithApiUrl(DefaultQueueAPIRootURL, params...)
 }
 
-func NewQueueClientWithApiUrl(apiUrl string) (*queue.Client, error) {
-	c, err := client.NewClient(apiUrl, client.WithUserAgent(UserAgent))
+func NewQueueClientWithApiUrl(apiUrl string, params ...client.ClientParam) (*queue.Client, error) {
+	c, err := client.NewClient(apiUrl, append([]client.ClientParam{
+		client.WithUserAgent(UserAgent),
+	}, params...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -76,12 +78,12 @@ func (ss ApiKeySecuritySource) ApiKeyAuth(ctx context.Context, operationName mes
 	return message.ApiKeyAuth{Token: ss.Token}, nil
 }
 
-func NewMessageClient(apiKey string) (*message.Client, error) {
-	return NewMessageClientWithApiUrl(DefaultMessageAPIRootURL, apiKey)
+func NewMessageClient(apiKey string, params ...client.ClientParam) (*message.Client, error) {
+	return NewMessageClientWithApiUrl(DefaultMessageAPIRootURL, apiKey, params...)
 }
 
-func NewMessageClientWithApiUrl(apiUrl, apiKey string) (*message.Client, error) {
-	c, err := client.NewClient(apiUrl,
+func NewMessageClientWithApiUrl(apiUrl, apiKey string, params ...client.ClientParam) (*message.Client, error) {
+	c, err := client.NewClient(apiUrl, append([]client.ClientParam{
 		client.WithUserAgent(UserAgent),
 		client.WithOptions(&client.Options{
 			RequestCustomizers: []sacloudhttp.RequestCustomizer{
@@ -89,8 +91,9 @@ func NewMessageClientWithApiUrl(apiUrl, apiKey string) (*message.Client, error) 
 					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 					return nil
 				},
-			},
-		}))
+			}}),
+	},
+		params...)...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### このPRはどういう変更を行いますか？

下記PRを参考に、clientParamsを受け入れるように変更しました。
[クライアント初期化時にapi-client-goのオプションをサポート. fix #4 by repeatedly · Pull Request #5 · sacloud/secretmanager-api-go](https://github.com/sacloud/secretmanager-api-go/pull/5)

### ドキュメントの変更は必要ですか？

いいえ