### PR TITLE
OpenAPIの更新に合わせたコード生成

### DIFF
--- a/apis/v1/queue/oas_faker_gen.go
+++ b/apis/v1/queue/oas_faker_gen.go
@@ -455,6 +455,15 @@ func (s *Error) SetFake() {
 }
 
 // SetFake set fake values.
+func (s *ExpireSeconds) SetFake() {
+	var unwrapped int
+	{
+		unwrapped = int(0)
+	}
+	*s = ExpireSeconds(unwrapped)
+}
+
+// SetFake set fake values.
 func (s *GetMessageCountBadRequest) SetFake() {
 	var unwrapped Error
 	{
@@ -865,12 +874,12 @@ func (s *RotateAPIKeyUnauthorized) SetFake() {
 func (s *Settings) SetFake() {
 	{
 		{
-			s.VisibilityTimeoutSeconds = int(0)
+			s.VisibilityTimeoutSeconds.SetFake()
 		}
 	}
 	{
 		{
-			s.ExpireSeconds = int(0)
+			s.ExpireSeconds.SetFake()
 		}
 	}
 }
@@ -882,4 +891,13 @@ func (s *Status) SetFake() {
 			s.QueueName = "string"
 		}
 	}
+}
+
+// SetFake set fake values.
+func (s *VisibilityTimeoutSeconds) SetFake() {
+	var unwrapped int
+	{
+		unwrapped = int(0)
+	}
+	*s = VisibilityTimeoutSeconds(unwrapped)
 }

--- a/apis/v1/queue/oas_json_gen.go
+++ b/apis/v1/queue/oas_json_gen.go
@@ -2304,6 +2304,46 @@ func (s *Error) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes ExpireSeconds as json.
+func (s ExpireSeconds) Encode(e *jx.Encoder) {
+	unwrapped := int(s)
+
+	e.Int(unwrapped)
+}
+
+// Decode decodes ExpireSeconds from json.
+func (s *ExpireSeconds) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ExpireSeconds to nil")
+	}
+	var unwrapped int
+	if err := func() error {
+		v, err := d.Int()
+		unwrapped = int(v)
+		if err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = ExpireSeconds(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ExpireSeconds) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ExpireSeconds) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes GetMessageCountBadRequest as json.
 func (s *GetMessageCountBadRequest) Encode(e *jx.Encoder) {
 	unwrapped := (*Error)(s)
@@ -4354,11 +4394,11 @@ func (s *Settings) Encode(e *jx.Encoder) {
 func (s *Settings) encodeFields(e *jx.Encoder) {
 	{
 		e.FieldStart("VisibilityTimeoutSeconds")
-		e.Int(s.VisibilityTimeoutSeconds)
+		s.VisibilityTimeoutSeconds.Encode(e)
 	}
 	{
 		e.FieldStart("ExpireSeconds")
-		e.Int(s.ExpireSeconds)
+		s.ExpireSeconds.Encode(e)
 	}
 }
 
@@ -4379,9 +4419,7 @@ func (s *Settings) Decode(d *jx.Decoder) error {
 		case "VisibilityTimeoutSeconds":
 			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Int()
-				s.VisibilityTimeoutSeconds = int(v)
-				if err != nil {
+				if err := s.VisibilityTimeoutSeconds.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -4391,9 +4429,7 @@ func (s *Settings) Decode(d *jx.Decoder) error {
 		case "ExpireSeconds":
 			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
-				v, err := d.Int()
-				s.ExpireSeconds = int(v)
-				if err != nil {
+				if err := s.ExpireSeconds.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -4548,6 +4584,46 @@ func (s *Status) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *Status) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes VisibilityTimeoutSeconds as json.
+func (s VisibilityTimeoutSeconds) Encode(e *jx.Encoder) {
+	unwrapped := int(s)
+
+	e.Int(unwrapped)
+}
+
+// Decode decodes VisibilityTimeoutSeconds from json.
+func (s *VisibilityTimeoutSeconds) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode VisibilityTimeoutSeconds to nil")
+	}
+	var unwrapped int
+	if err := func() error {
+		v, err := d.Int()
+		unwrapped = int(v)
+		if err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = VisibilityTimeoutSeconds(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s VisibilityTimeoutSeconds) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *VisibilityTimeoutSeconds) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/apis/v1/queue/oas_schemas_gen.go
+++ b/apis/v1/queue/oas_schemas_gen.go
@@ -785,6 +785,8 @@ func (s *Error) SetErrorMsg(val OptString) {
 	s.ErrorMsg = val
 }
 
+type ExpireSeconds int
+
 type GetMessageCountBadRequest Error
 
 func (*GetMessageCountBadRequest) getMessageCountRes() {}
@@ -1679,29 +1681,27 @@ func (*RotateAPIKeyUnauthorized) rotateAPIKeyRes() {}
 
 // Ref: #/components/schemas/Settings
 type Settings struct {
-	// 可視性タイムアウト (秒).
-	VisibilityTimeoutSeconds int `json:"VisibilityTimeoutSeconds"`
-	// 未処理メッセージ保存期間 (秒).
-	ExpireSeconds int `json:"ExpireSeconds"`
+	VisibilityTimeoutSeconds VisibilityTimeoutSeconds `json:"VisibilityTimeoutSeconds"`
+	ExpireSeconds            ExpireSeconds            `json:"ExpireSeconds"`
 }
 
 // GetVisibilityTimeoutSeconds returns the value of VisibilityTimeoutSeconds.
-func (s *Settings) GetVisibilityTimeoutSeconds() int {
+func (s *Settings) GetVisibilityTimeoutSeconds() VisibilityTimeoutSeconds {
 	return s.VisibilityTimeoutSeconds
 }
 
 // GetExpireSeconds returns the value of ExpireSeconds.
-func (s *Settings) GetExpireSeconds() int {
+func (s *Settings) GetExpireSeconds() ExpireSeconds {
 	return s.ExpireSeconds
 }
 
 // SetVisibilityTimeoutSeconds sets the value of VisibilityTimeoutSeconds.
-func (s *Settings) SetVisibilityTimeoutSeconds(val int) {
+func (s *Settings) SetVisibilityTimeoutSeconds(val VisibilityTimeoutSeconds) {
 	s.VisibilityTimeoutSeconds = val
 }
 
 // SetExpireSeconds sets the value of ExpireSeconds.
-func (s *Settings) SetExpireSeconds(val int) {
+func (s *Settings) SetExpireSeconds(val ExpireSeconds) {
 	s.ExpireSeconds = val
 }
 
@@ -1720,3 +1720,5 @@ func (s *Status) GetQueueName() string {
 func (s *Status) SetQueueName(val string) {
 	s.QueueName = val
 }
+
+type VisibilityTimeoutSeconds int

--- a/apis/v1/queue/oas_test_examples_gen_test.go
+++ b/apis/v1/queue/oas_test_examples_gen_test.go
@@ -420,6 +420,18 @@ func TestError_Examples(t *testing.T) {
 		})
 	}
 }
+func TestExpireSeconds_EncodeDecode(t *testing.T) {
+	var typ ExpireSeconds
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 ExpireSeconds
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
 func TestGetMessageCountBadRequest_EncodeDecode(t *testing.T) {
 	var typ GetMessageCountBadRequest
 	typ.SetFake()
@@ -766,5 +778,17 @@ func TestStatus_EncodeDecode(t *testing.T) {
 	require.True(t, std.Valid(data), "Encoded: %s", data)
 
 	var typ2 Status
+	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
+}
+func TestVisibilityTimeoutSeconds_EncodeDecode(t *testing.T) {
+	var typ VisibilityTimeoutSeconds
+	typ.SetFake()
+
+	e := jx.Encoder{}
+	typ.Encode(&e)
+	data := e.Bytes()
+	require.True(t, std.Valid(data), "Encoded: %s", data)
+
+	var typ2 VisibilityTimeoutSeconds
 	require.NoError(t, typ2.Decode(jx.DecodeBytes(data)))
 }

--- a/apis/v1/queue/oas_validators_gen.go
+++ b/apis/v1/queue/oas_validators_gen.go
@@ -266,6 +266,23 @@ func (s *DeleteQueueOK) Validate() error {
 	return nil
 }
 
+func (s ExpireSeconds) Validate() error {
+	alias := (int)(s)
+	if err := (validate.Int{
+		MinSet:        true,
+		Min:           60,
+		MaxSet:        true,
+		Max:           1209600,
+		MinExclusive:  false,
+		MaxExclusive:  false,
+		MultipleOfSet: false,
+		MultipleOf:    0,
+	}).Validate(int64(alias)); err != nil {
+		return errors.Wrap(err, "int")
+	}
+	return nil
+}
+
 func (s *GetQueueOK) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -384,17 +401,8 @@ func (s *Settings) Validate() error {
 
 	var failures []validate.FieldError
 	if err := func() error {
-		if err := (validate.Int{
-			MinSet:        true,
-			Min:           5,
-			MaxSet:        true,
-			Max:           900,
-			MinExclusive:  false,
-			MaxExclusive:  false,
-			MultipleOfSet: false,
-			MultipleOf:    0,
-		}).Validate(int64(s.VisibilityTimeoutSeconds)); err != nil {
-			return errors.Wrap(err, "int")
+		if err := s.VisibilityTimeoutSeconds.Validate(); err != nil {
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -404,17 +412,8 @@ func (s *Settings) Validate() error {
 		})
 	}
 	if err := func() error {
-		if err := (validate.Int{
-			MinSet:        true,
-			Min:           60,
-			MaxSet:        true,
-			Max:           1209600,
-			MinExclusive:  false,
-			MaxExclusive:  false,
-			MultipleOfSet: false,
-			MultipleOf:    0,
-		}).Validate(int64(s.ExpireSeconds)); err != nil {
-			return errors.Wrap(err, "int")
+		if err := s.ExpireSeconds.Validate(); err != nil {
+			return err
 		}
 		return nil
 	}(); err != nil {
@@ -425,6 +424,23 @@ func (s *Settings) Validate() error {
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s VisibilityTimeoutSeconds) Validate() error {
+	alias := (int)(s)
+	if err := (validate.Int{
+		MinSet:        true,
+		Min:           5,
+		MaxSet:        true,
+		Max:           900,
+		MinExclusive:  false,
+		MaxExclusive:  false,
+		MultipleOfSet: false,
+		MultipleOf:    0,
+	}).Validate(int64(alias)); err != nil {
+		return errors.Wrap(err, "int")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

VisibilityTimeoutSecondsとExpireSecondsをSettingsのフィールドから個別のschemaに切り出す変更がOpenAPIに入ったので、生成コードを更新します。

### ドキュメントの変更は必要ですか？
いいえ