### PR TITLE
Use simplemq.Error instead of common error

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,12 +56,12 @@ func NewQueueClientWithApiUrl(apiUrl string, params ...client.ClientParam) (*que
 		client.WithUserAgent(UserAgent),
 	}, params...)...)
 	if err != nil {
-		return nil, err
+		return nil, NewError("NewQueueClientWithApiUrl", err)
 	}
 
 	v1Client, err := queue.NewClient(c.ServerURL(), DummySecuritySource{Token: "simplemq-client"}, queue.WithClient(c.NewHttpRequestDoer()))
 	if err != nil {
-		return nil, fmt.Errorf("create client: %w", err)
+		return nil, NewError("NewQueueClientWithApiUrl", fmt.Errorf("create client: %w", err))
 	}
 
 	return v1Client, nil
@@ -94,12 +94,12 @@ func NewMessageClientWithApiUrl(apiUrl, apiKey string, params ...client.ClientPa
 			}})},
 		params...)...)
 	if err != nil {
-		return nil, err
+		return nil, NewError("NewMessageClientWithApiUrl", err)
 	}
 
 	v1Client, err := message.NewClient(apiUrl, ApiKeySecuritySource{Token: apiKey}, message.WithClient(c.NewHttpRequestDoer()))
 	if err != nil {
-		return nil, fmt.Errorf("create client: %w", err)
+		return nil, NewError("NewMessageClientWithApiUrl", fmt.Errorf("create client: %w", err))
 	}
 
 	return v1Client, nil

--- a/error.go
+++ b/error.go
@@ -1,0 +1,43 @@
+// Copyright 2025- The sacloud/simplemq-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simplemq
+
+type Error struct {
+	msg string
+	err error
+}
+
+func (e *Error) Error() string {
+	if e.msg != "" {
+		if e.err != nil {
+			return "simplemq: " + e.msg + ": " + e.err.Error()
+		} else {
+			return "simplemq: " + e.msg
+		}
+	} else {
+		return "simplemq: " + e.err.Error()
+	}
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+func NewError(msg string, err error) *Error {
+	if err == nil {
+		return &Error{msg: msg}
+	}
+	return &Error{msg: msg, err: err}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,55 @@
+package simplemq
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "with msg and err",
+			err:  &Error{msg: "something failed", err: baseErr},
+			want: "simplemq: something failed: base error",
+		},
+		{
+			name: "with msg only",
+			err:  &Error{msg: "only msg"},
+			want: "simplemq: only msg",
+		},
+		{
+			name: "with err only",
+			err:  &Error{err: baseErr},
+			want: "simplemq: base error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewError("msg", baseErr)
+	if err.msg != "msg" || err.err != baseErr {
+		t.Errorf("NewError() did not set fields correctly")
+	}
+
+	err2 := NewError("msg only", nil)
+	if err2.msg != "msg only" || err2.err != nil {
+		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}

--- a/message.go
+++ b/message.go
@@ -51,20 +51,20 @@ func (op *messageOp) Send(ctx context.Context, content string) (*message.NewMess
 			QueueName: op.queueName,
 		})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Send", err)
 	}
 
 	switch r := res.(type) {
 	case *message.SendMessageOK:
 		return &r.Message, nil
 	case *message.SendMessageUnauthorized:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Send", errors.New(r.Message.Value))
 	case *message.SendMessageBadRequest:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Send", errors.New(r.Message.Value))
 	case *message.SendMessageInternalServerError:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Send", errors.New(r.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Send", errors.New("unknown error"))
 	}
 }
 
@@ -74,20 +74,20 @@ func (op *messageOp) Receive(ctx context.Context) ([]message.Message, error) {
 			QueueName: op.queueName,
 		})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Receive", err)
 	}
 
 	switch r := res.(type) {
 	case *message.ReceiveMessageOK:
 		return r.Messages, nil
 	case *message.ReceiveMessageUnauthorized:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Receive", errors.New(r.Message.Value))
 	case *message.ReceiveMessageBadRequest:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Receive", errors.New(r.Message.Value))
 	case *message.ReceiveMessageInternalServerError:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("Receive", errors.New(r.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Receive", errors.New("unknown error"))
 	}
 }
 
@@ -98,22 +98,22 @@ func (op *messageOp) ExtendTimeout(ctx context.Context, messageID string) (*mess
 			MessageId: message.MessageId(messageID),
 		})
 	if err != nil {
-		return nil, err
+		return nil, NewError("ExtendTimeout", err)
 	}
 
 	switch r := res.(type) {
 	case *message.ExtendMessageTimeoutOK:
 		return &r.Message, nil
 	case *message.ExtendMessageTimeoutUnauthorized:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutBadRequest:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutNotFound:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutInternalServerError:
-		return nil, errors.New(r.Message.Value)
+		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("ExtendTimeout", errors.New("unknown error"))
 	}
 }
 
@@ -124,21 +124,21 @@ func (op *messageOp) Delete(ctx context.Context, messageID string) error {
 			MessageId: message.MessageId(messageID),
 		})
 	if err != nil {
-		return err
+		return NewError("Delete", err)
 	}
 
 	switch r := res.(type) {
 	case *message.DeleteMessageOK:
 		return nil
 	case *message.DeleteMessageUnauthorized:
-		return errors.New(r.Message.Value)
+		return NewError("Delete", errors.New(r.Message.Value))
 	case *message.DeleteMessageBadRequest:
-		return errors.New(r.Message.Value)
+		return NewError("Delete", errors.New(r.Message.Value))
 	case *message.DeleteMessageNotFound:
-		return errors.New(r.Message.Value)
+		return NewError("Delete", errors.New(r.Message.Value))
 	case *message.DeleteMessageInternalServerError:
-		return errors.New(r.Message.Value)
+		return NewError("Delete", errors.New(r.Message.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("Delete", errors.New("unknown error"))
 	}
 }

--- a/queue.go
+++ b/queue.go
@@ -65,86 +65,86 @@ func (op *queueOp) Create(ctx context.Context, req queue.CreateQueueRequest) (*q
 	req.CommonServiceItem.Provider.Class = queue.NewOptCreateQueueRequestCommonServiceItemProviderClass(queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq)
 	res, err := op.client.CreateQueue(ctx, &req)
 	if err != nil {
-		return nil, err
+		return nil, NewError("Create", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.CreateQueueCreated:
 		return &r.CommonServiceItem, nil
 	case *queue.CreateQueueUnauthorized:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueBadRequest:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueConflict:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueInternalServerError:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Create", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) List(ctx context.Context) ([]queue.CommonServiceItem, error) {
 	res, err := op.client.GetQueues(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NewError("List", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.GetQueuesOK:
 		return r.CommonServiceItems, nil
 	case *queue.GetQueuesUnauthorized:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueuesBadRequest:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueuesInternalServerError:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("List", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) Get(ctx context.Context, id string) (*queue.CommonServiceItem, error) {
 	res, err := op.client.GetQueue(ctx, queue.GetQueueParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Get", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.GetQueueOK:
 		return &r.CommonServiceItem, nil
 	case *queue.GetQueueUnauthorized:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Get", errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueBadRequest:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Get", errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueNotFound:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Get", errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueInternalServerError:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Get", errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Get", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) Config(ctx context.Context, id string, req queue.ConfigQueueRequest) (*queue.CommonServiceItem, error) {
 	res, err := op.client.ConfigQueue(ctx, &req, queue.ConfigQueueParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Config", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.ConfigQueueOK:
 		return &r.CommonServiceItem, nil
 	case *queue.ConfigQueueUnauthorized:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueBadRequest:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueNotFound:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueInternalServerError:
-		return nil, errors.New(r.ErrorMsg.Value)
+		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Config", errors.New("unknown error"))
 	}
 }
 
@@ -153,87 +153,87 @@ func (op *queueOp) Delete(ctx context.Context, id string) error {
 		ID: id,
 	})
 	if err != nil {
-		return err
+		return NewError("Delete", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.DeleteQueueOK:
 		return nil
 	case *queue.DeleteQueueUnauthorized:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("Delete", errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueBadRequest:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("Delete", errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueNotFound:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("Delete", errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueInternalServerError:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("Delete", errors.New(r.ErrorMsg.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("Delete", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) CountMessages(ctx context.Context, id string) (int, error) {
 	res, err := op.client.GetMessageCount(ctx, queue.GetMessageCountParams{ID: id})
 	if err != nil {
-		return 0, err
+		return 0, NewError("CountMessages", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.GetMessageCountOK:
 		return r.SimpleMQ.GetCount(), nil
 	case *queue.GetMessageCountUnauthorized:
-		return 0, errors.New(r.ErrorMsg.Value)
+		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountBadRequest:
-		return 0, errors.New(r.ErrorMsg.Value)
+		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountNotFound:
-		return 0, errors.New(r.ErrorMsg.Value)
+		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountInternalServerError:
-		return 0, errors.New(r.ErrorMsg.Value)
+		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
 	default:
-		return 0, errors.New("unknown error")
+		return 0, NewError("CountMessages", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) RotateAPIKey(ctx context.Context, id string) (string, error) {
 	res, err := op.client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
 	if err != nil {
-		return "", err
+		return "", NewError("RotateAPIKey", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.RotateAPIKeyOK:
 		return r.SimpleMQ.GetApikey(), nil
 	case *queue.RotateAPIKeyUnauthorized:
-		return "", errors.New(r.ErrorMsg.Value)
+		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyBadRequest:
-		return "", errors.New(r.ErrorMsg.Value)
+		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyNotFound:
-		return "", errors.New(r.ErrorMsg.Value)
+		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyInternalServerError:
-		return "", errors.New(r.ErrorMsg.Value)
+		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
 	default:
-		return "", errors.New("unknown error")
+		return "", NewError("RotateAPIKey", errors.New("unknown error"))
 	}
 }
 
 func (op *queueOp) ClearMessages(ctx context.Context, id string) error {
 	res, err := op.client.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
 	if err != nil {
-		return err
+		return NewError("ClearMessages", err)
 	}
 
 	switch r := res.(type) {
 	case *queue.ClearQueueOK:
 		return nil
 	case *queue.ClearQueueUnauthorized:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueBadRequest:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueNotFound:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueInternalServerError:
-		return errors.New(r.ErrorMsg.Value)
+		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("ClearMessages", errors.New("unknown error"))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

通常のerrorを返すのではなくsimplemq独自のエラーを返すことにより、ユーザがエラーの判別をできるようにする。
msgには自由なメッセージを設定できるが現状は呼び出されている関数の名前を設定し、どこでエラーが起きたのかを分かりやすいようにしている。

### ドキュメントの変更は必要ですか？

必要なし