### PR TITLE
Use api-client-go's APIError

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,6 +14,10 @@
 
 package simplemq
 
+import (
+	client "github.com/sacloud/api-client-go"
+)
+
 type Error struct {
 	msg string
 	err error
@@ -36,8 +40,9 @@ func (e *Error) Unwrap() error {
 }
 
 func NewError(msg string, err error) *Error {
-	if err == nil {
-		return &Error{msg: msg}
-	}
 	return &Error{msg: msg, err: err}
+}
+
+func NewAPIError(method string, code int, err error) *Error {
+	return &Error{msg: method, err: client.NewAPIError(code, "", err)}
 }

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,8 @@ package simplemq
 import (
 	"errors"
 	"testing"
+
+	client "github.com/sacloud/api-client-go"
 )
 
 func TestError_Error(t *testing.T) {
@@ -51,5 +53,19 @@ func TestNewError(t *testing.T) {
 	err2 := NewError("msg only", nil)
 	if err2.msg != "msg only" || err2.err != nil {
 		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}
+
+func TestNewAPIError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewAPIError("msg", 404, baseErr)
+	if !client.IsNotFoundError(err) {
+		t.Errorf("IsNotFoundError is true for NewAPIError with 404")
+	}
+
+	err2 := NewAPIError("msg", 503, nil)
+	if client.IsNotFoundError(err2) {
+		t.Errorf("IsNotFoundError is false for NewAPIError with 503")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.1.0
 	github.com/ogen-go/ogen v1.14.0
-	github.com/sacloud/api-client-go v0.3.0
+	github.com/sacloud/api-client-go v0.3.2
 	github.com/sacloud/go-http v0.1.9
 	github.com/stretchr/testify v1.10.0
 )
@@ -22,11 +22,11 @@ require (
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sacloud/packages-go v0.0.10 // indirect
+	github.com/sacloud/packages-go v0.0.11 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -39,10 +41,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sacloud/api-client-go v0.3.0 h1:NLA2BpZ5welAXBPxgmXSCjgn/k0ShDB0x5kmUHl7TJ4=
 github.com/sacloud/api-client-go v0.3.0/go.mod h1:v8ke3pxVQ9TCWEbMkfbLX8NMeGiPpE+uDwlgcUWfMgM=
+github.com/sacloud/api-client-go v0.3.2 h1:INbdSpQbyGN9Ai4hQ+Gbv3UQcgtRPG2tJrOmqT7HGl0=
+github.com/sacloud/api-client-go v0.3.2/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/packages-go v0.0.10 h1:UiQGjy8LretewkRhsuna1TBM9Vz/l9FoYpQx+D+AOck=
 github.com/sacloud/packages-go v0.0.10/go.mod h1:f8QITBh9z4IZc4yE9j21Q8b0sXEMwRlRmhhjWeDVTYs=
+github.com/sacloud/packages-go v0.0.11 h1:hrRWLmfPM9w7GBs6xb5/ue6pEMl8t1UuDKyR/KfteHo=
+github.com/sacloud/packages-go v0.0.11/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/message.go
+++ b/message.go
@@ -51,20 +51,20 @@ func (op *messageOp) Send(ctx context.Context, content string) (*message.NewMess
 			QueueName: op.queueName,
 		})
 	if err != nil {
-		return nil, NewError("Send", err)
+		return nil, NewAPIError("Message.Send", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *message.SendMessageOK:
 		return &r.Message, nil
 	case *message.SendMessageUnauthorized:
-		return nil, NewError("Send", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Send", 401, errors.New(r.Message.Value))
 	case *message.SendMessageBadRequest:
-		return nil, NewError("Send", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Send", 400, errors.New(r.Message.Value))
 	case *message.SendMessageInternalServerError:
-		return nil, NewError("Send", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Send", 500, errors.New(r.Message.Value))
 	default:
-		return nil, NewError("Send", errors.New("unknown error"))
+		return nil, NewAPIError("Message.Send", 0, nil)
 	}
 }
 
@@ -74,20 +74,20 @@ func (op *messageOp) Receive(ctx context.Context) ([]message.Message, error) {
 			QueueName: op.queueName,
 		})
 	if err != nil {
-		return nil, NewError("Receive", err)
+		return nil, NewAPIError("Message.Receive", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *message.ReceiveMessageOK:
 		return r.Messages, nil
 	case *message.ReceiveMessageUnauthorized:
-		return nil, NewError("Receive", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Receive", 401, errors.New(r.Message.Value))
 	case *message.ReceiveMessageBadRequest:
-		return nil, NewError("Receive", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Receive", 400, errors.New(r.Message.Value))
 	case *message.ReceiveMessageInternalServerError:
-		return nil, NewError("Receive", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.Receive", 500, errors.New(r.Message.Value))
 	default:
-		return nil, NewError("Receive", errors.New("unknown error"))
+		return nil, NewAPIError("Message.Receive", 0, nil)
 	}
 }
 
@@ -98,22 +98,22 @@ func (op *messageOp) ExtendTimeout(ctx context.Context, messageID string) (*mess
 			MessageId: message.MessageId(messageID),
 		})
 	if err != nil {
-		return nil, NewError("ExtendTimeout", err)
+		return nil, NewAPIError("Message.ExtendTimeout", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *message.ExtendMessageTimeoutOK:
 		return &r.Message, nil
 	case *message.ExtendMessageTimeoutUnauthorized:
-		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.ExtendTimeout", 401, errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutBadRequest:
-		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.ExtendTimeout", 400, errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutNotFound:
-		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.ExtendTimeout", 404, errors.New(r.Message.Value))
 	case *message.ExtendMessageTimeoutInternalServerError:
-		return nil, NewError("ExtendTimeout", errors.New(r.Message.Value))
+		return nil, NewAPIError("Message.ExtendTimeout", 500, errors.New(r.Message.Value))
 	default:
-		return nil, NewError("ExtendTimeout", errors.New("unknown error"))
+		return nil, NewAPIError("Message.ExtendTimeout", 0, nil)
 	}
 }
 
@@ -124,21 +124,21 @@ func (op *messageOp) Delete(ctx context.Context, messageID string) error {
 			MessageId: message.MessageId(messageID),
 		})
 	if err != nil {
-		return NewError("Delete", err)
+		return NewAPIError("Message.Delete", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *message.DeleteMessageOK:
 		return nil
 	case *message.DeleteMessageUnauthorized:
-		return NewError("Delete", errors.New(r.Message.Value))
+		return NewAPIError("Message.Delete", 401, errors.New(r.Message.Value))
 	case *message.DeleteMessageBadRequest:
-		return NewError("Delete", errors.New(r.Message.Value))
+		return NewAPIError("Message.Delete", 400, errors.New(r.Message.Value))
 	case *message.DeleteMessageNotFound:
-		return NewError("Delete", errors.New(r.Message.Value))
+		return NewAPIError("Message.Delete", 404, errors.New(r.Message.Value))
 	case *message.DeleteMessageInternalServerError:
-		return NewError("Delete", errors.New(r.Message.Value))
+		return NewAPIError("Message.Delete", 500, errors.New(r.Message.Value))
 	default:
-		return NewError("Delete", errors.New("unknown error"))
+		return NewAPIError("Message.Delete", 0, nil)
 	}
 }

--- a/queue.go
+++ b/queue.go
@@ -65,86 +65,86 @@ func (op *queueOp) Create(ctx context.Context, req queue.CreateQueueRequest) (*q
 	req.CommonServiceItem.Provider.Class = queue.NewOptCreateQueueRequestCommonServiceItemProviderClass(queue.CreateQueueRequestCommonServiceItemProviderClassSimplemq)
 	res, err := op.client.CreateQueue(ctx, &req)
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, NewAPIError("Queue.Create", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.CreateQueueCreated:
 		return &r.CommonServiceItem, nil
 	case *queue.CreateQueueUnauthorized:
-		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Create", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueBadRequest:
-		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Create", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueConflict:
-		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Create", 409, errors.New(r.ErrorMsg.Value))
 	case *queue.CreateQueueInternalServerError:
-		return nil, NewError("Create", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Create", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, NewError("Create", errors.New("unknown error"))
+		return nil, NewAPIError("Queue.Create", 0, nil)
 	}
 }
 
 func (op *queueOp) List(ctx context.Context) ([]queue.CommonServiceItem, error) {
 	res, err := op.client.GetQueues(ctx)
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, NewAPIError("Queue.List", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.GetQueuesOK:
 		return r.CommonServiceItems, nil
 	case *queue.GetQueuesUnauthorized:
-		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.List", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueuesBadRequest:
-		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.List", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueuesInternalServerError:
-		return nil, NewError("List", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.List", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, NewError("List", errors.New("unknown error"))
+		return nil, NewAPIError("Queue.List", 0, nil)
 	}
 }
 
 func (op *queueOp) Read(ctx context.Context, id string) (*queue.CommonServiceItem, error) {
 	res, err := op.client.GetQueue(ctx, queue.GetQueueParams{ID: id})
 	if err != nil {
-		return nil, NewError("Read", err)
+		return nil, NewAPIError("Queue.Read", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.GetQueueOK:
 		return &r.CommonServiceItem, nil
 	case *queue.GetQueueUnauthorized:
-		return nil, NewError("Read", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Read", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueBadRequest:
-		return nil, NewError("Read", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Read", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueNotFound:
-		return nil, NewError("Read", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Read", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.GetQueueInternalServerError:
-		return nil, NewError("Read", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Read", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, NewError("Read", errors.New("unknown error"))
+		return nil, NewAPIError("Queue.Read", 0, nil)
 	}
 }
 
 func (op *queueOp) Config(ctx context.Context, id string, req queue.ConfigQueueRequest) (*queue.CommonServiceItem, error) {
 	res, err := op.client.ConfigQueue(ctx, &req, queue.ConfigQueueParams{ID: id})
 	if err != nil {
-		return nil, NewError("Config", err)
+		return nil, NewAPIError("Queue.Config", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.ConfigQueueOK:
 		return &r.CommonServiceItem, nil
 	case *queue.ConfigQueueUnauthorized:
-		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Config", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueBadRequest:
-		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Config", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueNotFound:
-		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Config", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.ConfigQueueInternalServerError:
-		return nil, NewError("Config", errors.New(r.ErrorMsg.Value))
+		return nil, NewAPIError("Queue.Config", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return nil, NewError("Config", errors.New("unknown error"))
+		return nil, NewAPIError("Queue.Config", 0, nil)
 	}
 }
 
@@ -160,15 +160,15 @@ func (op *queueOp) Delete(ctx context.Context, id string) error {
 	case *queue.DeleteQueueOK:
 		return nil
 	case *queue.DeleteQueueUnauthorized:
-		return NewError("Delete", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.Delete", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueBadRequest:
-		return NewError("Delete", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.Delete", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueNotFound:
-		return NewError("Delete", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.Delete", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.DeleteQueueInternalServerError:
-		return NewError("Delete", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.Delete", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return NewError("Delete", errors.New("unknown error"))
+		return NewAPIError("Queue.Delete", 0, nil)
 	}
 }
 
@@ -182,58 +182,58 @@ func (op *queueOp) CountMessages(ctx context.Context, id string) (int, error) {
 	case *queue.GetMessageCountOK:
 		return r.SimpleMQ.GetCount(), nil
 	case *queue.GetMessageCountUnauthorized:
-		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
+		return 0, NewAPIError("Queue.CountMessages", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountBadRequest:
-		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
+		return 0, NewAPIError("Queue.CountMessages", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountNotFound:
-		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
+		return 0, NewAPIError("Queue.CountMessages", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.GetMessageCountInternalServerError:
-		return 0, NewError("CountMessages", errors.New(r.ErrorMsg.Value))
+		return 0, NewAPIError("Queue.CountMessages", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return 0, NewError("CountMessages", errors.New("unknown error"))
+		return 0, NewAPIError("Queue.CountMessages", 0, nil)
 	}
 }
 
 func (op *queueOp) RotateAPIKey(ctx context.Context, id string) (string, error) {
 	res, err := op.client.RotateAPIKey(ctx, queue.RotateAPIKeyParams{ID: id})
 	if err != nil {
-		return "", NewError("RotateAPIKey", err)
+		return "", NewAPIError("Queue.RotateAPIKey", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.RotateAPIKeyOK:
 		return r.SimpleMQ.GetApikey(), nil
 	case *queue.RotateAPIKeyUnauthorized:
-		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
+		return "", NewAPIError("Queue.RotateAPIKey", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyBadRequest:
-		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
+		return "", NewAPIError("Queue.RotateAPIKey", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyNotFound:
-		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
+		return "", NewAPIError("Queue.RotateAPIKey", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.RotateAPIKeyInternalServerError:
-		return "", NewError("RotateAPIKey", errors.New(r.ErrorMsg.Value))
+		return "", NewAPIError("Queue.RotateAPIKey", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return "", NewError("RotateAPIKey", errors.New("unknown error"))
+		return "", NewAPIError("Queue.RotateAPIKey", 0, nil)
 	}
 }
 
 func (op *queueOp) ClearMessages(ctx context.Context, id string) error {
 	res, err := op.client.ClearQueue(ctx, queue.ClearQueueParams{ID: id})
 	if err != nil {
-		return NewError("ClearMessages", err)
+		return NewAPIError("Queue.ClearMessages", 0, err)
 	}
 
 	switch r := res.(type) {
 	case *queue.ClearQueueOK:
 		return nil
 	case *queue.ClearQueueUnauthorized:
-		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.ClearMessages", 401, errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueBadRequest:
-		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.ClearMessages", 400, errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueNotFound:
-		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.ClearMessages", 404, errors.New(r.ErrorMsg.Value))
 	case *queue.ClearQueueInternalServerError:
-		return NewError("ClearMessages", errors.New(r.ErrorMsg.Value))
+		return NewAPIError("Queue.ClearMessages", 500, errors.New(r.ErrorMsg.Value))
 	default:
-		return NewError("ClearMessages", errors.New("unknown error"))
+		return NewAPIError("Queue.ClearMessages", 0, nil)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

fix #16

### このPRはどういう変更を行いますか？

api-client-goに実装されたAPIErrorを使ってエラーを返すようにする。
丸められたエラーではなくステータスコード等も取得できるようになるので、それによって処理を分けられるようになる。
terraformの404問題を解決可能。

### ドキュメントの変更は必要ですか？

必要無し