### PR TITLE
Fix queue list filter query encoding

### DIFF
--- a/apis/v1/queue/oas_client_gen.go
+++ b/apis/v1/queue/oas_client_gen.go
@@ -658,8 +658,9 @@ func (c *Client) sendGetQueues(ctx context.Context) (res GetQueuesRes, err error
 
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [1]string
-	pathParts[0] = `/commonserviceitem?{"Filter":{"Provider.Class":"simplemq"}}` // NOTE: ここだけOpenAPIで表現できず手動で書き加えている
+	pathParts[0] = "/commonserviceitem"
 	uri.AddPathParts(u, pathParts[:]...)
+	u.RawQuery = url.QueryEscape(`{"Filter":{"Provider.Class":"simplemq"}}`) // NOTE: ここだけOpenAPIで表現できず手動で書き加えている
 
 	r, err := ht.NewRequest(ctx, "GET", u)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -54,6 +55,31 @@ func TestNewQueueClient_WithCustomEndpoint(t *testing.T) {
 
 	requests := tracker.Requests()
 	assert.Len(requests, 1)
+}
+
+// TestNewQueueClient_FilterQueryParam OpenAPIで表現できず生成コードへのpatchで対応しているURLクエリパラメータが正しく付与されているか
+func TestNewQueueClient_FilterQueryParam(t *testing.T) {
+	assert := require.New(t)
+
+	tracker := newMockRequestTracker()
+	defer tracker.Close()
+
+	var theClient saclient.Client
+	err := theClient.SetEnviron([]string{"SAKURA_ENDPOINTS_SIMPLE_MQ_QUEUE=" + tracker.URL()})
+	assert.NoError(err)
+
+	client, err := simplemq.NewQueueClient(&theClient)
+	assert.NoError(err)
+	assert.NotNil(client)
+
+	queueAPI := simplemq.NewQueueOp(client)
+	_, _ = queueAPI.List(t.Context())
+
+	requests := tracker.Requests()
+	assert.Len(requests, 1)
+	assert.Equal("/commonserviceitem", requests[0].URL.Path)
+	expectedQuery := url.QueryEscape(`{"Filter":{"Provider.Class":"simplemq"}}`)
+	assert.Equal(expectedQuery, requests[0].URL.RawQuery)
 }
 
 func TestNewMessageClient(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sacloud/simplemq-api-go
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 tool github.com/ogen-go/ogen/cmd/ogen
 

--- a/patch/01_list_filter.patch
+++ b/patch/01_list_filter.patch
@@ -2,12 +2,12 @@ diff --git a/apis/v1/queue/oas_client_gen.go b/apis/v1/queue/oas_client_gen.go
 index 6ab5c8d..27d14d4 100644
 --- a/apis/v1/queue/oas_client_gen.go
 +++ b/apis/v1/queue/oas_client_gen.go
-@@ -658,7 +658,7 @@ func (c *Client) sendGetQueues(ctx context.Context) (res GetQueuesRes, err error
+@@ -658,7 +658,8 @@ func (c *Client) sendGetQueues(ctx context.Context) (res GetQueuesRes, err error
  
  	u := uri.Clone(c.requestURL(ctx))
  	var pathParts [1]string
--	pathParts[0] = "/commonserviceitem"
-+	pathParts[0] = `/commonserviceitem?{"Filter":{"Provider.Class":"simplemq"}}` // NOTE: ここだけOpenAPIで表現できず手動で書き加えている
+ 	pathParts[0] = "/commonserviceitem"
  	uri.AddPathParts(u, pathParts[:]...)
++	u.RawQuery = url.QueryEscape(`{"Filter":{"Provider.Class":"simplemq"}}`) // NOTE: ここだけOpenAPIで表現できず手動で書き加えている
  
  	r, err := ht.NewRequest(ctx, "GET", u)


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

さくらのクラウドAPI `GET /commonserviceitem`にパラメータを指定する際はクエリストリングにJSONを指定する必要がある
参考: https://manual.sakura.ad.jp/cloud-api/1.1/

simplemq-api-goでもこの実装がされているが、`?`を含めてURLエンコードをしてしまっており正しくリクエストが行えていなかった。
このPRではクエリストリングの組み立て部分を修正し正しく処理されるようにした

テスト結果:

<details>


```
$ TESTARGS="-count=1" make testacc
running 'go test' with TESTACC=1...
TESTACC=1 go test ./... -count=1 --tags=acctest -v -timeout=120m -parallel=8 ;
=== RUN   TestError_Error
=== RUN   TestError_Error/with_msg_and_err
=== RUN   TestError_Error/with_msg_only
=== RUN   TestError_Error/with_err_only
--- PASS: TestError_Error (0.00s)
    --- PASS: TestError_Error/with_msg_and_err (0.00s)
    --- PASS: TestError_Error/with_msg_only (0.00s)
    --- PASS: TestError_Error/with_err_only (0.00s)
=== RUN   TestNewError
--- PASS: TestNewError (0.00s)
=== RUN   TestNewAPIError
--- PASS: TestNewAPIError (0.00s)
=== RUN   TestNewQueueClient
--- PASS: TestNewQueueClient (0.00s)
=== RUN   TestNewQueueClient_WithCustomEndpoint
--- PASS: TestNewQueueClient_WithCustomEndpoint (0.00s)
=== RUN   TestNewQueueClient_FilterQueryParam
--- PASS: TestNewQueueClient_FilterQueryParam (0.00s)
=== RUN   TestNewMessageClient
--- PASS: TestNewMessageClient (0.00s)
=== RUN   TestNewMessageClient_WithCustomEndpoint
--- PASS: TestNewMessageClient_WithCustomEndpoint (0.00s)
=== RUN   TestMessageAPI
--- PASS: TestMessageAPI (2.64s)
=== RUN   TestQueueAPI
--- PASS: TestQueueAPI (3.26s)
PASS
ok  	github.com/sacloud/simplemq-api-go	6.432s
=== RUN   TestDeleteMessageBadRequest_EncodeDecode
--- PASS: TestDeleteMessageBadRequest_EncodeDecode (0.00s)
=== RUN   TestDeleteMessageInternalServerError_EncodeDecode
--- PASS: TestDeleteMessageInternalServerError_EncodeDecode (0.00s)
=== RUN   TestDeleteMessageNotFound_EncodeDecode
--- PASS: TestDeleteMessageNotFound_EncodeDecode (0.00s)
=== RUN   TestDeleteMessageOK_EncodeDecode
--- PASS: TestDeleteMessageOK_EncodeDecode (0.00s)
=== RUN   TestDeleteMessageTooManyRequests_EncodeDecode
--- PASS: TestDeleteMessageTooManyRequests_EncodeDecode (0.00s)
=== RUN   TestDeleteMessageUnauthorized_EncodeDecode
--- PASS: TestDeleteMessageUnauthorized_EncodeDecode (0.00s)
=== RUN   TestError_EncodeDecode
--- PASS: TestError_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutBadRequest_EncodeDecode
--- PASS: TestExtendMessageTimeoutBadRequest_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutInternalServerError_EncodeDecode
--- PASS: TestExtendMessageTimeoutInternalServerError_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutNotFound_EncodeDecode
--- PASS: TestExtendMessageTimeoutNotFound_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutOK_EncodeDecode
--- PASS: TestExtendMessageTimeoutOK_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutTooManyRequests_EncodeDecode
--- PASS: TestExtendMessageTimeoutTooManyRequests_EncodeDecode (0.00s)
=== RUN   TestExtendMessageTimeoutUnauthorized_EncodeDecode
--- PASS: TestExtendMessageTimeoutUnauthorized_EncodeDecode (0.00s)
=== RUN   TestMessage_EncodeDecode
--- PASS: TestMessage_EncodeDecode (0.00s)
=== RUN   TestMessageContent_EncodeDecode
--- PASS: TestMessageContent_EncodeDecode (0.00s)
=== RUN   TestMessageId_EncodeDecode
--- PASS: TestMessageId_EncodeDecode (0.00s)
=== RUN   TestNewMessage_EncodeDecode
--- PASS: TestNewMessage_EncodeDecode (0.00s)
=== RUN   TestReceiveMessageBadRequest_EncodeDecode
--- PASS: TestReceiveMessageBadRequest_EncodeDecode (0.00s)
=== RUN   TestReceiveMessageInternalServerError_EncodeDecode
--- PASS: TestReceiveMessageInternalServerError_EncodeDecode (0.00s)
=== RUN   TestReceiveMessageOK_EncodeDecode
--- PASS: TestReceiveMessageOK_EncodeDecode (0.00s)
=== RUN   TestReceiveMessageTooManyRequests_EncodeDecode
--- PASS: TestReceiveMessageTooManyRequests_EncodeDecode (0.00s)
=== RUN   TestReceiveMessageUnauthorized_EncodeDecode
--- PASS: TestReceiveMessageUnauthorized_EncodeDecode (0.00s)
=== RUN   TestSendMessageBadRequest_EncodeDecode
--- PASS: TestSendMessageBadRequest_EncodeDecode (0.00s)
=== RUN   TestSendMessageInternalServerError_EncodeDecode
--- PASS: TestSendMessageInternalServerError_EncodeDecode (0.00s)
=== RUN   TestSendMessageOK_EncodeDecode
--- PASS: TestSendMessageOK_EncodeDecode (0.00s)
=== RUN   TestSendMessageTooManyRequests_EncodeDecode
--- PASS: TestSendMessageTooManyRequests_EncodeDecode (0.00s)
=== RUN   TestSendMessageUnauthorized_EncodeDecode
--- PASS: TestSendMessageUnauthorized_EncodeDecode (0.00s)
=== RUN   TestSendRequest_EncodeDecode
--- PASS: TestSendRequest_EncodeDecode (0.00s)
PASS
ok  	github.com/sacloud/simplemq-api-go/apis/v1/message	0.857s
=== RUN   TestClearQueueBadRequest_EncodeDecode
--- PASS: TestClearQueueBadRequest_EncodeDecode (0.00s)
=== RUN   TestClearQueueInternalServerError_EncodeDecode
--- PASS: TestClearQueueInternalServerError_EncodeDecode (0.00s)
=== RUN   TestClearQueueNotFound_EncodeDecode
--- PASS: TestClearQueueNotFound_EncodeDecode (0.00s)
=== RUN   TestClearQueueOK_EncodeDecode
--- PASS: TestClearQueueOK_EncodeDecode (0.00s)
=== RUN   TestClearQueueOKSimpleMQ_EncodeDecode
--- PASS: TestClearQueueOKSimpleMQ_EncodeDecode (0.00s)
=== RUN   TestClearQueueUnauthorized_EncodeDecode
--- PASS: TestClearQueueUnauthorized_EncodeDecode (0.00s)
=== RUN   TestCommonServiceItem_EncodeDecode
--- PASS: TestCommonServiceItem_EncodeDecode (0.00s)
=== RUN   TestCommonServiceItemID_EncodeDecode
--- PASS: TestCommonServiceItemID_EncodeDecode (0.00s)
=== RUN   TestCommonServiceItemIcon_EncodeDecode
--- PASS: TestCommonServiceItemIcon_EncodeDecode (0.00s)
=== RUN   TestCommonServiceItemIconID_EncodeDecode
--- PASS: TestCommonServiceItemIconID_EncodeDecode (0.00s)
=== RUN   TestConfigQueueBadRequest_EncodeDecode
--- PASS: TestConfigQueueBadRequest_EncodeDecode (0.00s)
=== RUN   TestConfigQueueInternalServerError_EncodeDecode
--- PASS: TestConfigQueueInternalServerError_EncodeDecode (0.00s)
=== RUN   TestConfigQueueNotFound_EncodeDecode
--- PASS: TestConfigQueueNotFound_EncodeDecode (0.00s)
=== RUN   TestConfigQueueOK_EncodeDecode
--- PASS: TestConfigQueueOK_EncodeDecode (0.00s)
=== RUN   TestConfigQueueRequest_EncodeDecode
--- PASS: TestConfigQueueRequest_EncodeDecode (0.00s)
=== RUN   TestConfigQueueRequestCommonServiceItem_EncodeDecode
--- PASS: TestConfigQueueRequestCommonServiceItem_EncodeDecode (0.00s)
=== RUN   TestConfigQueueRequestCommonServiceItemIcon_EncodeDecode
--- PASS: TestConfigQueueRequestCommonServiceItemIcon_EncodeDecode (0.00s)
=== RUN   TestConfigQueueRequestCommonServiceItemIconID_EncodeDecode
--- PASS: TestConfigQueueRequestCommonServiceItemIconID_EncodeDecode (0.00s)
=== RUN   TestConfigQueueUnauthorized_EncodeDecode
--- PASS: TestConfigQueueUnauthorized_EncodeDecode (0.00s)
=== RUN   TestCreateQueueBadRequest_EncodeDecode
--- PASS: TestCreateQueueBadRequest_EncodeDecode (0.00s)
=== RUN   TestCreateQueueConflict_EncodeDecode
--- PASS: TestCreateQueueConflict_EncodeDecode (0.00s)
=== RUN   TestCreateQueueCreated_EncodeDecode
--- PASS: TestCreateQueueCreated_EncodeDecode (0.00s)
=== RUN   TestCreateQueueInternalServerError_EncodeDecode
--- PASS: TestCreateQueueInternalServerError_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequest_EncodeDecode
--- PASS: TestCreateQueueRequest_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequestCommonServiceItem_EncodeDecode
--- PASS: TestCreateQueueRequestCommonServiceItem_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequestCommonServiceItemIcon_EncodeDecode
--- PASS: TestCreateQueueRequestCommonServiceItemIcon_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequestCommonServiceItemIconID_EncodeDecode
--- PASS: TestCreateQueueRequestCommonServiceItemIconID_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequestCommonServiceItemProvider_EncodeDecode
--- PASS: TestCreateQueueRequestCommonServiceItemProvider_EncodeDecode (0.00s)
=== RUN   TestCreateQueueRequestCommonServiceItemProviderClass_EncodeDecode
--- PASS: TestCreateQueueRequestCommonServiceItemProviderClass_EncodeDecode (0.00s)
=== RUN   TestCreateQueueUnauthorized_EncodeDecode
--- PASS: TestCreateQueueUnauthorized_EncodeDecode (0.00s)
=== RUN   TestDeleteQueueBadRequest_EncodeDecode
--- PASS: TestDeleteQueueBadRequest_EncodeDecode (0.00s)
=== RUN   TestDeleteQueueInternalServerError_EncodeDecode
--- PASS: TestDeleteQueueInternalServerError_EncodeDecode (0.00s)
=== RUN   TestDeleteQueueNotFound_EncodeDecode
--- PASS: TestDeleteQueueNotFound_EncodeDecode (0.00s)
=== RUN   TestDeleteQueueOK_EncodeDecode
--- PASS: TestDeleteQueueOK_EncodeDecode (0.00s)
=== RUN   TestDeleteQueueUnauthorized_EncodeDecode
--- PASS: TestDeleteQueueUnauthorized_EncodeDecode (0.00s)
=== RUN   TestError_EncodeDecode
--- PASS: TestError_EncodeDecode (0.00s)
=== RUN   TestError_Examples
=== RUN   TestError_Examples/Test1
=== RUN   TestError_Examples/Test2
=== RUN   TestError_Examples/Test3
=== RUN   TestError_Examples/Test4
--- PASS: TestError_Examples (0.00s)
    --- PASS: TestError_Examples/Test1 (0.00s)
    --- PASS: TestError_Examples/Test2 (0.00s)
    --- PASS: TestError_Examples/Test3 (0.00s)
    --- PASS: TestError_Examples/Test4 (0.00s)
=== RUN   TestExpireSeconds_EncodeDecode
--- PASS: TestExpireSeconds_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountBadRequest_EncodeDecode
--- PASS: TestGetMessageCountBadRequest_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountInternalServerError_EncodeDecode
--- PASS: TestGetMessageCountInternalServerError_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountNotFound_EncodeDecode
--- PASS: TestGetMessageCountNotFound_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountOK_EncodeDecode
--- PASS: TestGetMessageCountOK_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountOKSimpleMQ_EncodeDecode
--- PASS: TestGetMessageCountOKSimpleMQ_EncodeDecode (0.00s)
=== RUN   TestGetMessageCountUnauthorized_EncodeDecode
--- PASS: TestGetMessageCountUnauthorized_EncodeDecode (0.00s)
=== RUN   TestGetQueueBadRequest_EncodeDecode
--- PASS: TestGetQueueBadRequest_EncodeDecode (0.00s)
=== RUN   TestGetQueueInternalServerError_EncodeDecode
--- PASS: TestGetQueueInternalServerError_EncodeDecode (0.00s)
=== RUN   TestGetQueueNotFound_EncodeDecode
--- PASS: TestGetQueueNotFound_EncodeDecode (0.00s)
=== RUN   TestGetQueueOK_EncodeDecode
--- PASS: TestGetQueueOK_EncodeDecode (0.00s)
=== RUN   TestGetQueueUnauthorized_EncodeDecode
--- PASS: TestGetQueueUnauthorized_EncodeDecode (0.00s)
=== RUN   TestGetQueuesBadRequest_EncodeDecode
--- PASS: TestGetQueuesBadRequest_EncodeDecode (0.00s)
=== RUN   TestGetQueuesInternalServerError_EncodeDecode
--- PASS: TestGetQueuesInternalServerError_EncodeDecode (0.00s)
=== RUN   TestGetQueuesOK_EncodeDecode
--- PASS: TestGetQueuesOK_EncodeDecode (0.00s)
=== RUN   TestGetQueuesUnauthorized_EncodeDecode
--- PASS: TestGetQueuesUnauthorized_EncodeDecode (0.00s)
=== RUN   TestProvider_EncodeDecode
--- PASS: TestProvider_EncodeDecode (0.00s)
=== RUN   TestProviderClass_EncodeDecode
--- PASS: TestProviderClass_EncodeDecode (0.00s)
=== RUN   TestQueueName_EncodeDecode
--- PASS: TestQueueName_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyBadRequest_EncodeDecode
--- PASS: TestRotateAPIKeyBadRequest_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyInternalServerError_EncodeDecode
--- PASS: TestRotateAPIKeyInternalServerError_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyNotFound_EncodeDecode
--- PASS: TestRotateAPIKeyNotFound_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyOK_EncodeDecode
--- PASS: TestRotateAPIKeyOK_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyOKSimpleMQ_EncodeDecode
--- PASS: TestRotateAPIKeyOKSimpleMQ_EncodeDecode (0.00s)
=== RUN   TestRotateAPIKeyUnauthorized_EncodeDecode
--- PASS: TestRotateAPIKeyUnauthorized_EncodeDecode (0.00s)
=== RUN   TestSettings_EncodeDecode
--- PASS: TestSettings_EncodeDecode (0.00s)
=== RUN   TestStatus_EncodeDecode
--- PASS: TestStatus_EncodeDecode (0.00s)
=== RUN   TestVisibilityTimeoutSeconds_EncodeDecode
--- PASS: TestVisibilityTimeoutSeconds_EncodeDecode (0.00s)
PASS
ok  	github.com/sacloud/simplemq-api-go/apis/v1/queue	1.200s
```

</details>

### ドキュメントの変更は必要ですか？

no